### PR TITLE
feat: Actions for managing GitHub self hosted runner in AWS

### DIFF
--- a/aws/create-github-runner-aws-action/README.md
+++ b/aws/create-github-runner-aws-action/README.md
@@ -1,0 +1,62 @@
+# create-github-runner-aws-action
+
+GitHub action for provisioning a dedicated GitHub self hosted runner in AWS as ECS task.
+
+The runner will be labeled with a unique identifier associated. This identifier is also set as
+tag of the ECS task. For using a runner provisioned like that, just set the requirement labels
+of the self hosted runner as shown below.
+
+## Usage example
+
+This is just an example of a task that lists S3 buckets, running on a dedicated self hosted runner
+provisioned by this action.
+
+```yml
+name: Simple example
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  create_runner:
+    name: Create Self-Hosted Runner
+    runs-on: ubuntu-22.04
+    strategy:
+      matrix:
+        index: [1]
+      fail-fast: true
+    environment: ${{ inputs.environment }}
+    outputs:
+      runner_name: ${{ steps.start_runner.outputs.runner_name }}
+
+    steps:
+      - name: Start GitHub Runner
+        id: start_runner
+        uses: pagopa/eng-github-actions-iac-template/create-github-runner-aws-action@v1
+        with:
+          aws_region: ${{ vars.AWS_REGION }}
+          iam_role_arn: ${{ vars.IAM_ROLE }}
+          ecs_cluster_name: ${{ vars.ECS_CLUSTER_NAME }}
+          ecs_task_definition: ${{ vars.ECS_TASK_DEFINITION }}
+          ecs_container_name: github-runner
+          ecs_task_subnet_id: ${{ vars.SUBNET_ID }}
+          ecs_task_sec_group: ${{ vars.SEC_GROUP_ID }}
+          pat_token: ${{ secrets.BOT_TOKEN }}
+
+  list_s3_buckets:
+    name: Just an example, list S3 buckets
+    # set here the required label of the hosted runner as the runner name returned by the create job
+    runs-on: [self-hosted, "${{ needs.create_runner.outputs.runner_name }}"]
+    environment: dev
+    needs: create_runner
+    steps:
+      - name: List S3 buckets
+        shell: bash
+        run: aws s3 ls
+```
+
+## Cleanup the runner
+
+Use the [dedicated action](../remove-github-runner-aws-action/) for cleaning up a runner 
+provisioned by this action.

--- a/aws/create-github-runner-aws-action/action.yml
+++ b/aws/create-github-runner-aws-action/action.yml
@@ -1,0 +1,81 @@
+name: "Create GitHub self hosted runner"
+description: "Create a GitHub self hosted runner on AWS"
+
+inputs:
+  aws_region:
+    description: "AWS region code"
+    required: true
+  iam_role_arn:
+    description: "ARN of the IAM role to assume"
+    required: true
+  ecs_cluster_name:
+    description: "ECS cluster"
+    required: true
+  ecs_task_definition:
+    description: "ECS task definition family[:revision] or full ARN"
+    required: true
+  ecs_container_name:
+    description: "Name of the gh runner container in the ECS task definition"
+    required: true
+  ecs_task_subnet_id:
+    description: "ID of the subnet where the task will run"
+    required: true
+  ecs_task_sec_group:
+    description: "ID of security group to attach to the task"
+    required: true
+  pat_token:
+    description: "GitHub PAT token to access APIs to manage self hosted runner"
+    required: true
+
+outputs:
+  runner_name:
+    value: ${{ steps.create_github_runner.outputs.runner_name }}
+    description: 'Unique name of the self-hosted runner'
+
+runs:
+  using: "composite"
+  steps:
+    - name: Configure AWS Credentials
+      uses: aws-actions/configure-aws-credentials@v4
+      with:
+        aws-region: ${{ inputs.aws_region }}
+        role-to-assume: ${{ inputs.iam_role_arn }}
+
+    - name: Create GitHub Runner
+      id: create_github_runner
+      shell: bash
+      run: |
+        set -eo pipefail
+
+        REGISTRATION_TOKEN=$(curl -s \
+          -X POST \
+          -H "Accept: application/vnd.github+json" \
+          -H "Authorization: Bearer ${{ inputs.pat_token }}" \
+          https://api.github.com/repos/${{ github.repository }}/actions/runners/registration-token | jq ".token" -r)
+
+        TIMESTAMP=$(date +%s)
+        RUNNER_NAME="${{ github.run_id }}-${{ matrix.index }}-${TIMESTAMP}"
+        GITHUB_REPOSITORY="https://github.com/${{ github.repository }}"
+        echo "runner_name=${RUNNER_NAME}" >> $GITHUB_OUTPUT
+
+        echo "{\"awsvpcConfiguration\":{\"assignPublicIp\":\"DISABLED\",
+            \"securityGroups\":[\"${{ inputs.ecs_task_sec_group }}\"],
+            \"subnets\":[\"${{ inputs.ecs_task_subnet_id }}\"]}}" > network_config.json
+        
+        echo "{\"containerOverrides\":[{\"name\":\"${{ inputs.ecs_container_name }}\",\"environment\":[
+              {\"name\":\"RUNNER_NAME\",\"value\":\"${RUNNER_NAME}\"},
+              {\"name\":\"GITHUB_REPOSITORY\",\"value\":\"${GITHUB_REPOSITORY}\"},
+              {\"name\":\"GITHUB_TOKEN\",\"value\":\"${REGISTRATION_TOKEN}\"},
+              {\"name\":\"LABELS\",\"value\":\"${RUNNER_NAME}\"}]}]}" > overrides.json
+
+        ECS_TASK_ID=$(aws ecs run-task \
+          --launch-type "FARGATE" \
+          --cluster "${{ inputs.ecs_cluster_name }}" \
+          --network-configuration file://./network_config.json \
+          --task-definition "${{ inputs.ecs_task_definition }}" \
+          --tags "key=runner_name,value=${RUNNER_NAME}" \
+          --overrides file://./overrides.json \
+          | jq -r '.tasks[0].taskArn' \
+          | cut -d "/" -f 3)
+
+        echo "[INFO] Started ECS task $ECS_TASK_ID"

--- a/aws/remove-github-runner-aws-action/README.md
+++ b/aws/remove-github-runner-aws-action/README.md
@@ -1,0 +1,78 @@
+# remove-github-runner-aws-action
+
+GitHub action for removing a GitHub self hosted runner in AWS as ECS task.
+Removing means: remove it from GitHub and stop the task in AWS.
+
+It is indended to be used for cleaning up runners created with the [dedicated action](../create-github-runner-aws-action/).
+
+The removal works by looking up runner and task by label and tag respectively, both with their 
+unique identifier generated in creation phase.
+
+## Usage example
+
+This is just an example of a task that lists S3 buckets, running on a dedicated self hosted runner
+provisioned by the create action, that will be cleaned up by this action.
+
+```yml
+name: Simple example
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  create_runner:
+    name: Create Self-Hosted Runner
+    runs-on: ubuntu-22.04
+    strategy:
+      matrix:
+        index: [1]
+      fail-fast: true
+    outputs:
+      runner_name: ${{ steps.start_runner.outputs.runner_name }}
+
+    steps:
+      - name: Start GitHub Runner
+        id: start_runner
+        uses: pagopa/eng-github-actions-iac-template/create-github-runner-aws-action@v1
+        with:
+          aws_region: ${{ vars.AWS_REGION }}
+          iam_role_arn: ${{ vars.IAM_ROLE }}
+          ecs_cluster_name: ${{ vars.ECS_CLUSTER_NAME }}
+          ecs_task_definition: ${{ vars.ECS_TASK_DEFINITION }}
+          ecs_container_name: github-runner
+          ecs_task_subnet_id: ${{ vars.SUBNET_ID }}
+          ecs_task_sec_group: ${{ vars.SEC_GROUP_ID }}
+          pat_token: ${{ secrets.BOT_TOKEN }}
+
+  list_s3_buckets:
+    name: Just an example, list S3 buckets
+    # set here the required label of the hosted runner as the runner name returned by the create job
+    runs-on: [self-hosted, "${{ needs.create_runner.outputs.runner_name }}"]
+    needs: create_runner
+    steps:
+      - name: List S3 buckets
+        shell: bash
+        run: aws s3 ls
+
+  delete_runner:
+    name: Delete Self-Hosted Runner
+    needs: [create_runner, list_s3_buckets]
+    strategy:
+      matrix:
+        index: [1]
+      fail-fast: true
+    if: ${{ always() }}
+    runs-on: ubuntu-22.04
+
+    steps:
+      - name: Remove Github Runner
+        id: remove_runner
+        uses: pagopa/eng-github-actions-iac-template/remove-github-runner-aws-action@v1
+        with:
+          aws_region: ${{ vars.AWS_REGION }}
+          iam_role_arn: ${{ vars.IAM_ROLE }}
+          ecs_cluster_name: ${{ vars.ECS_CLUSTER_NAME }}
+          pat_token: ${{ secrets.BOT_TOKEN }}
+          runner_name: ${{ needs.create_runner.outputs.runner_name }}
+```

--- a/aws/remove-github-runner-aws-action/action.yml
+++ b/aws/remove-github-runner-aws-action/action.yml
@@ -1,0 +1,84 @@
+name: "Cleanup GitHub self hosted runner"
+description: "Cleanup a GitHub self hosted runner on AWS"
+
+inputs:
+  aws_region:
+    description: "AWS region code"
+    required: true
+  iam_role_arn:
+    description: "ARN of the IAM role to assume"
+    required: true
+  ecs_cluster_name:
+    description: "ECS cluster"
+    required: true
+  pat_token:
+    description: "GitHub PAT token to access APIs to manage self hosted runner"
+    required: true
+  runner_name:
+    description: "Name of the GitHub runner to remove"
+    required: true
+
+runs:
+  using: "composite"
+  steps:
+    - name: Configure AWS Credentials
+      uses: aws-actions/configure-aws-credentials@v4
+      with:
+        aws-region: ${{ inputs.aws_region }}
+        role-to-assume: ${{ inputs.iam_role_arn }}
+
+    - name: Cleanup GitHub Runner
+      shell: bash
+      id: cleanup_github_runner
+      run: |
+        set -eo pipefail
+
+        GITHUB_RUNNER_ID=$(curl -s \
+          -H "Accept: application/vnd.github+json" \
+          -H "Authorization: Bearer ${{ inputs.pat_token }}" \
+          https://api.github.com/repos/${{ github.repository }}/actions/runners \
+          | jq '.runners | map(select(.name == "'${{ inputs.runner_name }}'")) | .[].id' -r)
+
+        ECS_TASK_ARN=$(aws resourcegroupstaggingapi get-resources \
+          --region ${{ inputs.aws_region }} \
+          --resource-type-filters ecs:task \
+          --tag-filters Key=runner_name,Values=${{ inputs.runner_name }} \
+          --max-items 1 \
+          | jq --raw-output '.ResourceTagMappingList[].ResourceARN')
+
+        aws ecs stop-task \
+          --cluster ${{ inputs.ecs_cluster_name }} \
+          --task ${ECS_TASK_ARN} > /dev/null
+
+        echo "[INFO] ECS task ${ECS_TASK_ID} stopped"
+
+        curl -s \
+          -X DELETE \
+          -H "Accept: application/vnd.github+json" \
+          -H "Authorization: Bearer ${{ inputs.pat_token }}" \
+          https://api.github.com/repos/${{ github.repository }}/actions/runners/${GITHUB_RUNNER_ID}
+
+        START_TIME=$(date +%s)
+        while [ $(( $(date +%s) - 120 )) -lt $START_TIME ]; do
+
+          echo "[INFO] Waiting for runner ${{ inputs.runner_name }} to be deleted from Github"
+
+          GITHUB_RUNNER_ID=$(curl -s \
+            -H "Accept: application/vnd.github+json" \
+            -H "Authorization: Bearer ${{ inputs.pat_token }}" \
+            https://api.github.com/repos/${{ github.repository }}/actions/runners \
+            | jq '.runners | map(select(.name == "'${{ inputs.runner_name }}'")) | .[].id' -r)
+
+          if [ -z "$GITHUB_RUNNER_ID" ]; then
+            echo "[INFO] Runner ${{ inputs.runner_name }} has been deleted"
+            break
+          fi
+
+          sleep 10
+
+        done
+
+        if [ -n "$GITHUB_RUNNER_ID" ]; then
+          echo "[ERROR] Runner ${{ inputs.runner_name }} was not deleted from Github" >&2
+          exit 1
+        fi


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->
Actions for using a GitHub self hosted runner in AWS as ECS task.

#### List of Changes
<!--- Describe your changes in detail -->
- Add action `create-github-runner-aws-action` for provisioning a GitHub runner as ECS task, dedicated to a specific workflow.
- Add action `remove-github-runner-aws-action` for removing a runner created with the `create-github-runner-aws-action`.

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
A GitHub runner in a AWS VPC can be handy for interacting with AWS resources from pipelines.
These actions can be used before and after some GitHub jobs for running that jobs on a runner in the VPC.

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Chore (nothing changes by a user perspective)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
