### PR TITLE
chore: Remove `default_end_folder_depth` input from action

### DIFF
--- a/global/get-modifed-folders/README.md
+++ b/global/get-modifed-folders/README.md
@@ -13,7 +13,6 @@ The workflow:
 ## Inputs
 
 - `start_folder` (Optional): Starting index for path filtering. Default: `'/'`.
-- `default_end_folder_depth` (Optional): Default end index for path slicing. Default: `2`.
 - `include_patterns` (Required): Patterns to include in path filtering. Example:
   ```yaml
   "src,domains"
@@ -26,10 +25,12 @@ The workflow:
   ```yaml
   ".scripts,.utils"
   ```
+  
 - stopper_folders:` (Required) Pattern to stop at directory before the configured parameter. Example:` "env" will stop at any folder named "env"'
   ```yaml
     default: "env"
   ```
+  
 - include_folders:`(Optional) Folders to include in the sparse checkout`
   ```yaml
     default: "scripts,.utils"
@@ -54,7 +55,6 @@ The workflow:
         with:
           ignore_patterns: ".github,.devops,.vscode,.terraform-version"
           start_folder: "src"
-          default_end_folder_depth: 2
           include_patterns: "src,domains"
           stopper_folders: "env,tests,api,api_product,helm"
 ```

--- a/global/get-modifed-folders/action.yml
+++ b/global/get-modifed-folders/action.yml
@@ -6,9 +6,6 @@ inputs:
   start_folder:
     description: '(Optional) Starting index for path filtering'
     default: '/'
-  default_end_folder_depth:
-    description: '(Optional) Default end index for path slicing'
-    default: 2
   include_patterns:
     description: '(Required) Patterns to include in path filtering, comma separated'
     required: true
@@ -67,7 +64,6 @@ runs:
         DEFAULT_IGNORED_PATHS = "${{ inputs.ignore_patterns }}".split(",")
 
         STARTING_INDEX = "${{ inputs.start_folder }}"
-        DEFAULT_END_INDEX = ${{ inputs.default_end_folder_depth }}
         INCLUDE_PATTERNS = "${{ inputs.include_patterns }}".split(",")
         STOPPER_FOLDERS = "${{ inputs.stopper_folders }}".split(",")
         INCLUDE_FOLDERS = "${{ inputs.include_folders }}".split(",")


### PR DESCRIPTION
#### List of Changes
- Removed the `default_end_folder_depth` input from the action.
- Updated code dependencies to reflect the removal.
- Adjusted documentation to align with the changes.

#### Motivation and Context
The `default_end_folder_depth` input was no longer required, and its removal simplifies the configuration and streamlines the input interface.

#### How Has This Been Tested?
- Ran tests to ensure functionality remains consistent after the removal.
- Verified no side effects on dependent code or workflows.

#### Screenshots (if appropriate):

#### Types of changes
- [x] Chore (nothing changes by a user perspective)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.